### PR TITLE
[fix] 채팅 중복오류, 사라지는 오류 수정

### DIFF
--- a/src/service/Chatting/mmkvChatStorage.ts
+++ b/src/service/Chatting/mmkvChatStorage.ts
@@ -176,7 +176,7 @@ export const decrementUnreadCountBeforeTimestamp = (chatRoomId: string, timestam
         let messagesChanged = false;
 
         const updatedMessages = messages.map(message => {
-            if (message.createdAt < timestamp && message.unreadCount > 0) {
+            if (message.createdAt >= timestamp && message.unreadCount > 0) {
                 messagesChanged = true;
                 return { ...message, unreadCount: message.unreadCount - 1 };
             }


### PR DESCRIPTION
- 채팅 중복 오류 수정
서버에서 가져온 채팅 메시지의 경우 변경된 메시지도 같이 보내주기 때문에
메시지가 중복되면 업데이트된 메시지로 변경해 줘야함.

- 보낸 메시지 사라지는 오류 수정
user enter시에 저장된 메시지이외에도
현재 화면에 있는 메시지 messages, 버퍼에 있는 메시지 updatedMessageBuffer도 업데이트 해줘야 함.
저장된 메시지만 바꾸고, 그걸 화면으로 렌더링하면서 메시지 사라지는 오류 발생.